### PR TITLE
Update gemspec to support Faraday 0.9

### DIFF
--- a/callcredit.gemspec
+++ b/callcredit.gemspec
@@ -1,8 +1,7 @@
 require File.expand_path('../lib/callcredit/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'faraday',             '~> 0.8.0'
-  gem.add_runtime_dependency 'faraday_middleware',  '>= 0.8.2'
+  gem.add_runtime_dependency 'faraday_middleware',  '>= 0.8.2', '< 0.10'
   gem.add_runtime_dependency 'multi_xml',           '~> 0.5.1'
   gem.add_runtime_dependency 'nokogiri',            '~> 1.4'
   gem.add_runtime_dependency 'unicode_utils',       '~> 1.4.0'

--- a/lib/callcredit/middleware/check_response.rb
+++ b/lib/callcredit/middleware/check_response.rb
@@ -22,6 +22,6 @@ module Callcredit
       end
     end
 
-    Faraday.register_middleware :response, check_response: CheckResponse
+    Faraday::Response.register_middleware check_response: CheckResponse
   end
 end


### PR DESCRIPTION
Since https://github.com/lostisland/faraday_middleware/pull/88 faraday_middleware supports Faraday 0.9, so so can we.
