### PR TITLE
Include RID on all requests

### DIFF
--- a/lib/callcredit/request.rb
+++ b/lib/callcredit/request.rb
@@ -27,7 +27,7 @@ module Callcredit
         xml.callvalidate do
           authentication(xml)
           xml.sessions do
-            xml.session do
+            xml.session("RID" => Time.now.to_f) do
               xml.data do
                 personal_data(xml, check_data[:personal_data])
                 card_data(xml, check_data[:card_data])


### PR DESCRIPTION
That. Occasionally Callcredit will complain if this isn't included (or monotonically increasing).
