### PR TITLE
Permit versions of faraday_middleware up to v0.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ rvm:
   - 2.2.7
   - 2.1.10
   - 2.0.0
+before_install: gem update bundler
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
+  - 2.1.10
   - 2.0.0
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,4 @@ language: ruby
 rvm:
   - 2.1.0
   - 2.0.0
-notifications:
-  email:
-    recipients:
-      - grey@gocardless.com
 script: bundle exec rspec spec

--- a/callcredit.gemspec
+++ b/callcredit.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/callcredit/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'faraday_middleware',  '>= 0.8.2', '< 0.10'
+  gem.add_runtime_dependency 'faraday_middleware',  '>= 0.8.2', '< 0.13'
   gem.add_runtime_dependency 'multi_xml',           '~> 0.5.1'
   gem.add_runtime_dependency 'nokogiri',            '~> 1.4'
   gem.add_runtime_dependency 'unicode_utils',       '~> 1.4.0'


### PR DESCRIPTION
`faraday_middleware` has been updated, bringing a bunch of
new features and security fixes in v0.12.2.

Given that the gem hasn't hit a major version yet, locking the
dependencies up to the next minor version feels sensible to ensure
compatability.